### PR TITLE
Korrektur arnotron und qoreQyaS

### DIFF
--- a/_data/chatterliste.json
+++ b/_data/chatterliste.json
@@ -216,22 +216,6 @@
         ]
     },
     {
-        "Nick": "arnotron",
-        "Name": "Arne Böttger",
-        "NIC Handle": [
-            "APB9-RIPE"
-        ],
-        "ASN": [
-            20694
-        ],
-        "Organisation": [
-            {
-                "url": "http://www.nmmn.com/",
-                "name": "NMMN"
-            }
-        ]
-    },
-    {
         "Nick": "as.as.as",
         "Name": "Andre Scholz",
         "NIC Handle": [
@@ -3274,15 +3258,8 @@
         "NIC Handle": [
             "SG11315-RIPE"
         ],
-        "ASN": [
-            20694
-        ],
-        "Organisation": [
-            {
-                "url": "https://www.nmmn.com/",
-                "name": "NMMN New Media Markets & Networks IT-Services GmbH"
-            }
-        ]
+        "ASN": [],
+        "Organisation": []
     },
     {
         "Nick": "qybl",


### PR DESCRIPTION
arnotron und qoreQyaS arbeiten nicht mehr bei NMMN, letzteren dahingehend geupdated, ersteren ganz entfernt (last seen: ```2015-05-10.log.gz:[10:37:12] *** Quits: arnotron (~apb@ardbeg.rot26.de) (EOF From client)```)