### PR TITLE
Update motp in chatterliste.json

### DIFF
--- a/_data/chatterliste.json
+++ b/_data/chatterliste.json
@@ -3041,7 +3041,7 @@
             "BJOE1-RIPE"
         ],
         "ASN": [
-            201824
+            209379
         ],
         "Organisation": [
             {


### PR DESCRIPTION
AS201824 is no more. 
It's an ex AS, it’s expired and gone to meet it’s Maker. 
This is a late AS. It’s a stiff! Bereft of moving data, It rests in network heaven!

